### PR TITLE
deleted all lorem ipsum exaples texts

### DIFF
--- a/styles/core/_main.scss
+++ b/styles/core/_main.scss
@@ -102,8 +102,6 @@ strong {
 /*
 Layouts
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur viverra ante enim, cursus fringilla metus hendrerit non.
-
 Styleguide #{$sgi-layouts}
 */
 

--- a/styles/elements/_buttons.scss
+++ b/styles/elements/_buttons.scss
@@ -1,8 +1,6 @@
 /*
 Buttons
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur viverra ante enim, cursus fringilla metus hendrerit non.
-
 Styleguide #{$sgi-buttons}
 */
 
@@ -356,8 +354,6 @@ Styleguide #{$sgi-buttons-display}
 
 /*
 Button group
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur viverra ante enim, cursus fringilla metus hendrerit non.
 
 Styleguide #{$sgi-button-group}
 


### PR DESCRIPTION
I've deleted all the "lorem ipsum" explanations text from the components documentation

Please, review @PablitoGS 
