### PR TITLE
cover image when it's in code (<img>)

### DIFF
--- a/html/media_board.html
+++ b/html/media_board.html
@@ -44,6 +44,41 @@
 			</section>
 
 		</div>
+
+    <div class="container container-expanded panel-canvas">
+
+    		<section class="media-board">
+				<div class="item item1 effect-image js-item"
+                     style="background-image: url(//media.infojobs.net/appgrade/backgrounds/bheader-grid-01.jpg )">
+					<a href="#">
+						<div class="gradient">
+							<div class="caption">
+								<h1 class="title">Miles de empresas buscan en InfoJobs</h1>
+								<p class="description">Multinacional francesa especializada en bricolaje con presencia en 13 pa�ses</p>
+							</div>
+						</div>
+					</a>
+				</div>
+
+				<div class="item-group clearfix">
+					<div class="item item2 effect-image js-item"
+                         style="background-image:
+                         url(//media.infojobs.net/appgrade/backgrounds/bheader-grid-02.jpg )">
+						<a href="#">
+							<img src="//media.infojobs.net/portales/ij/appgrade/pictures/pic-video-alegrias.png" />
+						</a>
+					</div>
+					<div class="item item3 effect-color">
+						<a href="#">
+							<div class="caption">
+								<h3 class="title">Cada vez m�s empresas contratan m�s profesionales freelance.</h3>
+							</div>
+						</a>
+					</div>
+				</div>
+			</section>
+
+		</div>
 	</div>
     <script src="//es-static0.infojobs.com/jquery.js"></script>
     <script src="../js/media-board.js"></script>

--- a/styles/components/media-board.scss
+++ b/styles/components/media-board.scss
@@ -114,6 +114,13 @@
 			}
 		}
 
+		img {
+			object-fit: cover;
+			display: block;
+			max-height: 180px;
+			width: 100%;
+		}
+
 	}
 
 	.item-group {
@@ -316,6 +323,10 @@
 					line-height: 22px;
 					font-family: Proximanova;
 				}
+			}
+
+			img {
+				max-height: none;
 			}
 		}
 


### PR DESCRIPTION
I added a new case in media-board: cover image when it's in code (<img>)
I added a second board on the example HTML with this case
Please, review @PablitoGS 
