### PR TITLE
fix text opacity on custom background

### DIFF
--- a/styles/components/custom-background.scss
+++ b/styles/components/custom-background.scss
@@ -37,7 +37,7 @@ $overlay-opacity: (60,85);
 
 	.overlay-#{$value} {
 
-        position: relative;
+    position: relative;
 
 		&::before {
             content: "";
@@ -51,5 +51,9 @@ $overlay-opacity: (60,85);
             background-color: #000;
             opacity: $value/100;
 		}
+
+    .inner {
+        position: relative;
+    }
 	}
 }

--- a/styles/components/modal.scss
+++ b/styles/components/modal.scss
@@ -315,7 +315,7 @@ Styleguide #{$sgi-modal-content}
 		color: white;
 	}
 
-	+ form {
+	~ form {
 		margin-top: 57px;
 	}
 }


### PR DESCRIPTION
When text it's inside a custom background with some opacity, this text inherits that opacity. I've fixed this case.
Otherwise I've fixed the rule for add margin top on modal windows.
Please, review @PablitoGS 
