### PR TITLE
changed architecture for candidates/companies variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-text-replace": "0.4.0",
     "kss": "2.0.2",
     "load-grunt-tasks": "^3.3.0",
-    "node-sass": "3.4.2",
+    "node-sass": "^3.4.2",
     "time-grunt": "^1.2.2"
   }
 }

--- a/styles/candidates.scss
+++ b/styles/candidates.scss
@@ -1,5 +1,5 @@
-$stylesheet: 'candidates';
-
+@import "generics/vars";
+@import "generics/vars-ca";
 @import "rubik"; // generics.scss
 				 // core.scss
 				 // elements.scss

--- a/styles/companies.scss
+++ b/styles/companies.scss
@@ -1,6 +1,5 @@
-
-$stylesheet: 'companies';
-
+@import "generics/vars";
+@import "generics/vars-co";
 @import "rubik"; // generics.scss
 				 // core.scss
 				 // elements.scss
@@ -8,12 +7,12 @@ $stylesheet: 'companies';
 // components
 @import 'components/components';
 
-//custom
-@import 'custom/custom';
-
 // specifics components
 @import 'components/header-co';
 @import 'components/value-proposition-co';
+
+//custom
+@import 'custom/alta-co-segmentada';
 
  // tools
 @import 'generics/tools';

--- a/styles/rubik.scss
+++ b/styles/rubik.scss
@@ -1,18 +1,6 @@
 // generics
-
 @import "generics/docs-index";
-@import "generics/vars";
-
-@if $stylesheet == "candidates" {
-    @import "generics/vars-ca";
-}
-
-@if $stylesheet == "companies" {
-    @import "generics/vars-co";
-}
-
 @import "generics/vars-theme";
-
 @import "generics/functions";
 @import "generics/mixins";
 @import "generics/placeholders";


### PR DESCRIPTION
We need to update node-sass version (from 3.4.2 to latest available -> ^3.4.2)
Because that, we need to change the imports from rubik, candidates and companies partials and delete conditionals.
(it's the same PR that empleo)
Please, review @PablitoGS 