### PR TITLE
fix alignment on mixin badge

### DIFF
--- a/styles/components/badges.scss
+++ b/styles/components/badges.scss
@@ -30,6 +30,7 @@ Styleguide #{$sgi-badges}
 */
 
 @mixin badge {
+  align-self: flex-start;
   display: inline-table;
   font-family: $base-font-family;
   font-size: $small-font-size;


### PR DESCRIPTION
I've added alignment for `badge` component. `flex-start` is to force element to correct width