### PR TITLE
break vs hide

### DIFF
--- a/styles/generics/tools.scss
+++ b/styles/generics/tools.scss
@@ -1,4 +1,3 @@
-//generics
 @import "../core/print";
 
 /*------------------------------------*\
@@ -246,7 +245,7 @@ Styleguide #{$sgi-helpers}
 \*------------------------------------*/
 
 .hide {
-	display: none;
+	display: none !important; //we need important because .break class has display: block
 }
 
 @media only screen and (max-width: $mobile-start) {
@@ -329,11 +328,6 @@ Styleguide #{$sgi-helpers}
 		@include mediaquery ($bp-desktop) {
 			display: inline;
 		}
-	}
-
-	&-after::after {
-		content: '';
-		display: block;
 	}
 }
 


### PR DESCRIPTION
We have a problem when we add `hide` class to an element that already has class `break` because this one has `display: block`

There was an option https://css-tricks.com/injecting-line-break/ but doesn't work for us because we need `before` for some icons